### PR TITLE
Use the equal locs function, despite its name, so that we do a color …

### DIFF
--- a/modelstudio/src/com/hiveworkshop/rms/editor/model/util/ModelSaving/GeosetToMdlx.java
+++ b/modelstudio/src/com/hiveworkshop/rms/editor/model/util/ModelSaving/GeosetToMdlx.java
@@ -194,7 +194,7 @@ public class GeosetToMdlx {
 
 		animation.alpha = (float) geoset.getStaticAlpha();
 
-		if (geoset.find(MdlUtils.TOKEN_COLOR) != null || !geoset.getStaticColor().equals(new Vec3(1, 1, 1))) {
+		if (geoset.find(MdlUtils.TOKEN_COLOR) != null || !geoset.getStaticColor().equalLocs(new Vec3(1, 1, 1))) {
 			animation.flags |= 0x2;
 		}
 		animation.color = geoset.getStaticColor().toFloatArray();


### PR DESCRIPTION
…value comparison.

Some user approached me with model problems, and I found this difference in the generated model, where flag 0x2 was present when it should not be. I do not know for certain that this broke their model, but it appeared to be a likely contributor.